### PR TITLE
use root project settings for compileSdkVersion, buildToolsVersion, etc

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,20 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 23
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '23.0.1'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 23
+
+
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  compileSdkVersion _compileSdkVersion
+  buildToolsVersion _buildToolsVersion
 
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion 23
+    minSdkVersion _minSdkVersion
+    targetSdkVersion _targetSdkVersion
   }
 
   lintOptions {


### PR DESCRIPTION
This allows the project to upgrade to a newer android SDK version (as required by React Native 0.5.6)