### PR TITLE
improved SDK values -use SDK Version values from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,18 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  compileSdkVersion safeExtGet('compileSdkVersion', 26)
+  buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion 23
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 26)
+    versionCode 1
+    versionName "1.0"
   }
 
   lintOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,5 @@ android {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+" // From node_modules
+  compile "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}" // From node_modules
 }


### PR DESCRIPTION
Instead of assuming the `compileSdkVersion `, `targetSdkVersion`, etc, we can make it dynamic by reading it from the root project.


Android Target API Level 26 will be required in August 2018.
https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html

Therefore I wrote target values of 26 instead of 23

And the React Native team is already working on this:
https://github.com/facebook/react-native/issues/18095
https://github.com/facebook/react-native/pull/17741