### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.zoontek.rndevmenu" >
-    <uses-sdk android:minSdkVersion="16" />
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.zoontek.rndevmenu" />


### PR DESCRIPTION
Build tools version `28.+` starts refusing having the min-sdk in Manifest.

Removing it make the build success.

See https://github.com/react-community/react-native-maps/pull/2472/files for reference.