### PR TITLE
Include required React's subspecs as dependencies

### DIFF
--- a/RNDevMenu.podspec
+++ b/RNDevMenu.podspec
@@ -16,5 +16,7 @@ Pod::Spec.new do |s|
   s.source_files   = "ios/**/*.{h,m}"
   s.exclude_files  = "example/**/*"
 
-  s.dependency       "React"
+  s.dependency       "React/Core"
+  s.dependency       "React/DevSupport"
+  s.dependency       "React/RCTNetwork"
 end


### PR DESCRIPTION
Default `React` pod does not include `DevSupport` subspec as a dependency by default.

Having only `React` listed here raises the following compilation error:

```
▸ Compiling RNDevMenu.m

❌  /Users/me/Developer/project/node_modules/react-native-dev-menu/ios/RNDevMenu.m:1:9: 'React/RCTDevMenu.h' file not found

#import <React/RCTDevMenu.h>
```

After including `React/DevSupport` as an additional subspec, it raises:

```
▸ Compiling RCTBlobManager.mm

❌  /Users/me/Developer/project/node_modules/react-native/Libraries/Blob/RCTBlobManager.mm:13:9: 'React/RCTNetworking.h' file not found

#import <React/RCTNetworking.h>
```

So we have to also include `React/RCTNetwork` (which is also not included in `React/Core`).