### PR TITLE
Fix CocoaPods podspec for RN@v0.60.0

### DIFF
--- a/RNDevMenu.podspec
+++ b/RNDevMenu.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files   = "ios/**/*.{h,m}"
   s.exclude_files  = "example/**/*"
 
-  s.dependency       "React/Core"
-  s.dependency       "React/DevSupport"
-  s.dependency       "React/RCTNetwork"
+  s.dependency       "React-Core"
+  s.dependency       "React-DevSupport"
+  s.dependency       "React-RCTNetwork"
 end


### PR DESCRIPTION
In React Native 0.60.0, the [React.podspec was split into many podspecs, one per Xcode project](https://github.com/react-native-community/discussions-and-proposals/blob/master/proposals/0004-cocoapods-support-improvements.md). 

This is a breaking change and will probably require a new major release.