### PR TITLE
Change dependency, again

### DIFF
--- a/RNDevMenu.podspec
+++ b/RNDevMenu.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.exclude_files  = "example/**/*"
 
   s.dependency       "React-Core"
-  s.dependency       "React-DevSupport"
+  s.dependency       "React-Core/DevSupport"
   s.dependency       "React-RCTNetwork"
 end


### PR DESCRIPTION
I'm sorry. It's not me, it's facebook 😄

Maybe you can just leave it out altogether? Now that it's there by default.