### PR TITLE
Update Podspec to use new DevSupport pod

### DIFF
--- a/RNDevMenu.podspec
+++ b/RNDevMenu.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.exclude_files  = "example/**/*"
 
   s.dependency       "React-Core"
-  s.dependency       "React-DevSupport"
+  s.dependency       "React-Core/DevSupport"
   s.dependency       "React-RCTNetwork"
 end


### PR DESCRIPTION
With the update to RN `0.61.X`, the name of the DevSupport pod was changed from `React/DevSupport` to `React-Core/DevSupport`. I've updated this in the podspec file.